### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/pca9539"
 embedded-hal = { version = "0.2.7", features = ["unproven"] }
 bitmaps = { version = "3.1.0", default-features = false }
 cortex-m = { version = "0.7.4", optional = true }
-spin = { version = "0.9.2", optional = true }
+spin = { version = "0.9.8", optional = true }
 
 [dev-dependencies]
 mockall = "0.11.0"


### PR DESCRIPTION
Updates dependency to the patch version of 0.9.8

[Advisory](https://rustsec.org/advisories/RUSTSEC-2023-0031.html)