### PR TITLE
Fixed Clippy warnings regarding inconsistent lifetimes

### DIFF
--- a/src/expander.rs
+++ b/src/expander.rs
@@ -219,7 +219,7 @@ where
     /// Returns a pins container using Mutex based on critical sections
     /// Individual pins can be used across threads and interrupts, as long just running on a single core
     #[cfg(feature = "cortex-m")]
-    pub fn pins_cs_mutex(&mut self) -> Pins<B, CsMutexGuard<B>> {
+    pub fn pins_cs_mutex(&mut self) -> Pins<B, CsMutexGuard<'_, B>> {
         Pins::new(CsMutexGuard::new(CsMutex::new(RefCell::new(self))))
     }
 
@@ -228,7 +228,7 @@ where
     /// However, this requires a system supporting spin mutexes, which are generally only
     /// available on systems with Atomic CAS
     #[cfg(feature = "spin")]
-    pub fn pins_spin_mutex(&mut self) -> Pins<B, SpinGuard<B>> {
+    pub fn pins_spin_mutex(&mut self) -> Pins<B, SpinGuard<'_, B>> {
         Pins::new(SpinGuard::new(SpinMutex::new(RefCell::new(self))))
     }
 

--- a/src/expander.rs
+++ b/src/expander.rs
@@ -212,7 +212,7 @@ where
     /// This is the most efficient way of using individual pins
     /// The downside is, that these pins are neither Send or Sync, so can only be used in single-threaded
     /// and interrupt-free applications
-    pub fn pins(&mut self) -> Pins<B, LockFreeGuard<B>> {
+    pub fn pins(&mut self) -> Pins<B, LockFreeGuard<'_, B>> {
         Pins::new(LockFreeGuard::new(RefCell::new(self)))
     }
 

--- a/src/pins.rs
+++ b/src/pins.rs
@@ -180,7 +180,7 @@ impl<B: I2c<SevenBitAddress>, R: RefGuard<B>> Pins<B, R> {
 
     /// Returns an individual pin, which state gets updated synchronously
     /// **The library does not prevent multiple parallel instances of the same pin.**
-    pub fn get_pin(&self, bank: Bank, id: PinID) -> Pin<B, R, Input, RegularAccessMode> {
+    pub fn get_pin(&self, bank: Bank, id: PinID) -> Pin<'_, B, R, Input, RegularAccessMode> {
         Pin::regular(&self.guard, bank, id)
     }
 
@@ -188,7 +188,7 @@ impl<B: I2c<SevenBitAddress>, R: RefGuard<B>> Pins<B, R> {
     /// The status is explicitly updated. This allows a more efficient status query and assignment,
     /// as the status is only updated once for all pins.
     /// **The library does not prevent multiple parallel instances of the same pin.**
-    pub fn get_refreshable_pin(&self, bank: Bank, id: PinID) -> Pin<B, R, Input, RefreshMode> {
+    pub fn get_refreshable_pin(&self, bank: Bank, id: PinID) -> Pin<'_, B, R, Input, RefreshMode> {
         Pin::refreshable(&self.guard, bank, id)
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -950,6 +950,6 @@ fn get_pins(expander: &mut PCA9539<MockI2CBus>) -> Pins<MockI2CBus, SpinGuard<Mo
 
 /// Testing lock-free RefGuard
 #[cfg(not(feature = "spin"))]
-fn get_pins(expander: &mut PCA9539<MockI2CBus>) -> Pins<MockI2CBus, LockFreeGuard<MockI2CBus>> {
+fn get_pins(expander: &mut PCA9539<MockI2CBus>) -> Pins<MockI2CBus, LockFreeGuard<'_, MockI2CBus>> {
     expander.pins()
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -944,7 +944,7 @@ fn test_refreshable_pin_invert_polarity_error() {
 
 /// Testing spin based RefGuard
 #[cfg(feature = "spin")]
-fn get_pins(expander: &mut PCA9539<MockI2CBus>) -> Pins<MockI2CBus, SpinGuard<MockI2CBus>> {
+fn get_pins(expander: &mut PCA9539<MockI2CBus>) -> Pins<MockI2CBus, SpinGuard<'_, MockI2CBus>> {
     expander.pins_spin_mutex()
 }
 


### PR DESCRIPTION
Just fixing current Clippy warnings.