### PR TITLE
Sync state API

### DIFF
--- a/src/expander.rs
+++ b/src/expander.rs
@@ -320,6 +320,20 @@ where
         }
     }
 
+    /// (Re)writes the internal state (mode, polarity, output state) to the configuration registers.
+    /// May be useful after power resenting the expander IC to ensure the software matches the
+    /// hardware state.
+    pub fn sync_state(&mut self) -> Result<(), B::Error> {
+        self.write_polarity(Bank::Bank0)?;
+        self.write_polarity(Bank::Bank1)?;
+
+        self.write_output_state(Bank::Bank0)?;
+        self.write_output_state(Bank::Bank1)?;
+
+        self.write_conf(Bank::Bank0)?;
+        self.write_conf(Bank::Bank1)
+    }
+
     /// Reads and returns the given input register
     fn read_input_register(&mut self, command: u8) -> Result<u8, RefreshInputError<B>> {
         self.bus

--- a/src/expander.rs
+++ b/src/expander.rs
@@ -82,6 +82,20 @@
 //!#
 //! expander.reverse_polarity(Bank0, Pin3, true).unwrap();
 //! ```
+//! ## (Re)sync the internal state
+//! If needed, e.g. in case of IC reset, the complete internal state (polarity, mode, output state)
+//! may be resent.
+//! ```
+//!# use pca9539::example::DummyI2CBus;
+//!# use pca9539::expander::Bank::Bank0;
+//!# use pca9539::expander::PCA9539;
+//!# use pca9539::expander::PinID::{Pin1, Pin3};
+//!#
+//!# let i2c_bus = DummyI2CBus::default();
+//!# let mut  expander = PCA9539::new(i2c_bus, 0x74);
+//!#
+//! expander.sync_state().unwrap();
+//! ```
 
 #[cfg(feature = "cortex-m")]
 use crate::guard::CsMutexGuard;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ pub mod pins;
 
 pub(crate) mod pin_refreshable;
 pub(crate) mod pin_regular;
+pub mod sync_state;
 
 #[cfg(test)]
 mod mocks;

--- a/src/pins.rs
+++ b/src/pins.rs
@@ -158,6 +158,25 @@
 //!# #[cfg(feature = "spin")]
 //! let pins = expander.pins_spin_mutex();
 //! ```
+//! ## (Re)sync the internal state
+//! If needed, e.g. in case of IC reset, the complete internal state (polarity, mode, output state)
+//! may be resent.
+//!
+//! If called the method sends the state of **all banks**, not just the bank of the given pin.
+//! ```
+//!# use pca9539::example::DummyI2CBus;
+//!# use pca9539::expander::Bank::{Bank0, Bank1};
+//!# use pca9539::expander::PCA9539;
+//!# use pca9539::expander::PinID::{Pin0, Pin1, Pin2, Pin3, Pin4};
+//!# use embedded_hal::digital::{InputPin, PinState, OutputPin};
+//!# use pca9539::pins::RefreshableOutputPin;
+//!#
+//!# let i2c_bus = DummyI2CBus::default();
+//!# let mut  expander = PCA9539::new(i2c_bus, 0x74);
+//!# let pins = expander.pins();
+//! let pin = pins.get_refreshable_pin(Bank0, Pin0);
+//! pin.sync_state().unwrap();
+//! ```
 use crate::expander::{Bank, Mode, PinID};
 use crate::guard::RefGuard;
 pub use crate::pin_refreshable::{RefreshableInputPin, RefreshableOutputPin};

--- a/src/pins.rs
+++ b/src/pins.rs
@@ -289,4 +289,17 @@ where
 
         result
     }
+
+    /// (Re)writes the internal state (mode, polarity, output state) of all banks to the configuration registers.
+    /// May be useful after power resenting the expander IC to ensure the software matches the
+    /// hardware state.
+    pub fn sync_state(&self) -> Result<(), B::Error> {
+        let mut result = Ok(());
+
+        self.expander.access(|expander| {
+            result = expander.sync_state();
+        });
+
+        result
+    }
 }

--- a/src/sync_state.rs
+++ b/src/sync_state.rs
@@ -1,0 +1,11 @@
+use core::fmt::Debug;
+
+/// General interface for syncing state
+pub trait SyncState {
+    type Error: Debug;
+
+    /// (Re)writes the internal state (mode, polarity, output state) of all banks to the configuration registers.
+    /// May be useful after power resenting the expander IC to ensure the software matches the
+    /// hardware state.
+    fn sync_state(&self) -> Result<(), Self::Error>;
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -9,6 +9,7 @@ use crate::guard::SpinGuard;
 use crate::mocks::{BusMockBuilder, DummyError, MockI2CBus};
 use crate::pin_refreshable::{RefreshableInputPin, RefreshableOutputPin};
 use crate::pins::Pins;
+use crate::sync_state::SyncState;
 use embedded_hal::digital::{InputPin, OutputPin, PinState, StatefulOutputPin};
 
 #[test]


### PR DESCRIPTION
If needed, e.g., in case of IC reset, the complete internal state (polarity, mode, output state) may be resent.